### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [quality-gate]
     if: always() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    permissions:
+      contents: read
     steps:
       - name: 📊 Build Summary
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/ThomasHeim11/CypherpunkSecurityWebsite/security/code-scanning/26](https://github.com/ThomasHeim11/CypherpunkSecurityWebsite/security/code-scanning/26)

To fix the issue, we need to add a `permissions` block to the `notify` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the job only generates a build summary and outputs information, it likely only requires `contents: read` permissions. This change ensures that the job operates with the minimum necessary privileges, reducing the risk of misuse.

The `permissions` block should be added directly under the `notify` job definition in the `.github/workflows/ci.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
