### PR TITLE
Potential fix for code scanning alert no. 25: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,8 @@ jobs:
   quality-gate:
     name: 🚪 Quality Gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       [
         code-quality,


### PR DESCRIPTION
Potential fix for [https://github.com/ThomasHeim11/CypherpunkSecurityWebsite/security/code-scanning/25](https://github.com/ThomasHeim11/CypherpunkSecurityWebsite/security/code-scanning/25)

To fix the issue, we will add a `permissions` block to the `quality-gate` job. Since this job only checks the results of other jobs and does not perform any write operations, it only requires `contents: read` permissions. This change will explicitly limit the permissions of the `GITHUB_TOKEN` for this job, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
